### PR TITLE
DD-130: Fix dataseat-dsp build

### DIFF
--- a/oap-application/src/main/java/oap/application/Kernel.java
+++ b/oap-application/src/main/java/oap/application/Kernel.java
@@ -131,7 +131,9 @@ public class Kernel implements Closeable {
             Object linked = services.get( Module.Reference.of( reference ).name );
             if( linked == null )
                 throw new ApplicationException( "for " + service.name + " listening object " + reference + " is not found" );
-            var m = Reflect.reflect( linked.getClass() ).method( methodName ).orElse( null );
+            var m = Reflect.reflect( linked.getClass() )
+                .method( methodName )
+                .orElse( null );
             if( m != null ) m.invoke( linked, instance );
             else
                 throw new ReflectException( "listener " + listener + " should have method " + methodName + " in " + reference );
@@ -208,7 +210,7 @@ public class Kernel implements Closeable {
 
         fixServiceName();
         fixDeps();
-        var map = instantiateServices( config );
+        var map = instantiateServices();
         registerServices( map );
         linkServices( map );
         startServices( map );
@@ -225,7 +227,7 @@ public class Kernel implements Closeable {
                 service.name = service.name != null ? service.name : implName );
     }
 
-    private Map<String, ServiceInitialization> instantiateServices( ApplicationConfiguration config ) {
+    private Map<String, ServiceInitialization> instantiateServices() {
         var ret = new LinkedHashMap<String, ServiceInitialization>();
 
         var initializedServices = new LinkedHashSet<String>();
@@ -277,10 +279,8 @@ public class Kernel implements Closeable {
             log.trace( "linking service {}...", si.implementationName );
             linkLinks( si.service, si.instance );
             linkListeners( si.service, si.instance );
-            si.service.parameters.forEach( ( parameter, value ) -> {
-                linkService( new FieldLinkReflection( si.reflection, si.instance, parameter ), value, si,
-                    true );
-            } );
+            si.service.parameters.forEach( ( parameter, value ) -> linkService( new FieldLinkReflection( si.reflection,
+                    si.instance, parameter ), value, si, true ) );
 
         }
     }

--- a/oap-stdlib/src/main/java/oap/reflect/Reflection.java
+++ b/oap-stdlib/src/main/java/oap/reflect/Reflection.java
@@ -174,13 +174,36 @@ public class Reflection extends Annotated<Class<?>> {
     }
 
     public Optional<Method> method( Predicate<Method> matcher ) {
-        return this.methods.stream().filter( matcher ).findFirst();
+        return this.methods.stream()
+            .filter( matcher )
+            .findFirst();
     }
 
     public Optional<Method> method( Predicate<Method> matcher, Comparator<Method> comparator ) {
-        return this.methods.stream().sorted( comparator ).filter( matcher ).findFirst();
+        return this.methods.stream()
+            .sorted( comparator )
+            .filter( matcher )
+            .findFirst();
     }
 
+
+    /**
+     * @param name Method name
+     * @param parameters list
+     * @return {@link Method} - method wrapper of {@link java.lang.reflect.Method}
+     */
+    public Optional<Method> method( String name, List<Parameter> parameters ) {
+        return method( m -> Objects.equals( m.name(), name ) && m.parameters.equals( parameters ) );
+    }
+
+    /**
+     * @param name Method name
+     * @return {@link Method} - method wrapper of {@link java.lang.reflect.Method}
+     *
+     * @deprecated JVM is responsible to pick random method if there are several overloaded methods.
+     * Use {@link #method(String, List)} or {@link #method(java.lang.reflect.Method)} instead
+     */
+    @Deprecated
     public Optional<Method> method( String name ) {
         return method( m -> Objects.equals( m.name(), name ) );
     }
@@ -459,7 +482,6 @@ public class Reflection extends Annotated<Class<?>> {
 
         Parameter( java.lang.reflect.Parameter parameter ) {
             super( parameter );
-
         }
 
         public Reflection type() {

--- a/oap-ws/src/main/java/oap/ws/validate/JsonPartialValidatorPeer.java
+++ b/oap-ws/src/main/java/oap/ws/validate/JsonPartialValidatorPeer.java
@@ -52,7 +52,7 @@ public class JsonPartialValidatorPeer implements ValidatorPeer {
         this.validate = validate;
         this.instance = instance;
         this.method = Reflect.reflect( instance.getClass() )
-            .method( validate.methodName() )
+            .method( validate.methodName(), targetMethod.parameters )
             .orElseThrow( () -> new WsException( "No such method " + validate.methodName() ) );
     }
 

--- a/oap-ws/src/main/java/oap/ws/validate/MethodValidatorPeer.java
+++ b/oap-ws/src/main/java/oap/ws/validate/MethodValidatorPeer.java
@@ -43,7 +43,7 @@ public class MethodValidatorPeer implements ValidatorPeer {
     public MethodValidatorPeer( WsValidate validate, Reflection.Method targetMethod, Object instance, Type type ) {
         if( type == Type.PARAMETER )
             this.validators = Stream.of( validate.value() )
-                .<Validator>map( m -> new ParameterValidator( m, instance ) )
+                .<Validator>map( m -> new ParameterValidator( m, targetMethod, instance ) )
                 .toList();
         else
             this.validators = Stream.of( validate.value() )
@@ -62,9 +62,9 @@ public class MethodValidatorPeer implements ValidatorPeer {
         protected final Reflection.Method method;
         protected final Object instance;
 
-        protected Validator( String method, Object instance ) {
+        protected Validator( String method, Reflection.Method targetMethod, Object instance ) {
             this.method = Reflect.reflect( instance.getClass() )
-                .method( method )
+                .method( method, targetMethod.parameters )
                 .orElseThrow( () -> new WsException( "no such method " + method ) );
             this.instance = instance;
         }
@@ -73,8 +73,8 @@ public class MethodValidatorPeer implements ValidatorPeer {
     }
 
     private static class ParameterValidator extends Validator {
-        public ParameterValidator( String method, Object instatnce ) {
-            super( method, instatnce );
+        public ParameterValidator( String method, Reflection.Method targetMethod, Object instatnce ) {
+            super( method, targetMethod, instatnce );
         }
 
         @Override
@@ -87,7 +87,7 @@ public class MethodValidatorPeer implements ValidatorPeer {
         private final Map<String, Integer> validatorMethodParamIndices;
 
         protected MethodValidator( String method, Reflection.Method targetMethod, Object instance ) {
-            super( method, instance );
+            super( method, targetMethod, instance );
             validatorMethodParamIndices = Stream.of( targetMethod.parameters )
                 .map( Reflection.Parameter::name )
                 .zipWithIndex()
@@ -103,7 +103,7 @@ public class MethodValidatorPeer implements ValidatorPeer {
                 Integer argumentIndex = validatorMethodParamIndices.get( argumentName );
                 if( argumentIndex == null ) {
                     throw new IllegalArgumentException( argumentName + " required by validator " + this.method.name()
-                        + "is not supplied by web method" );
+                        + " is not supplied by web method" );
                 }
                 params[i] = ( ( Object[] ) value )[argumentIndex];
             }
@@ -112,7 +112,9 @@ public class MethodValidatorPeer implements ValidatorPeer {
             } catch( ReflectException e ) {
                 log.error( e.getMessage() );
                 log.info( "method = " + method.name() );
-                log.info( "method parameters = " + method.parameters.stream().map( p -> p.type().underlying ).collect( toList() ) );
+                log.info( "method parameters = " + method.parameters.stream()
+                    .map( p -> p.type().underlying )
+                    .collect( toList() ) );
                 log.info( "method parameters = " + Arrays.stream( params ).map( p -> p == null ? "<NULL>"
                     : p.getClass() ).collect( toList() ) );
                 throw e;

--- a/oap-ws/src/test/java/oap/ws/validate/ValidatorsTest.java
+++ b/oap-ws/src/test/java/oap/ws/validate/ValidatorsTest.java
@@ -27,14 +27,17 @@ package oap.ws.validate;
 import oap.reflect.Reflect;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Method;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ValidatorsTest {
     @Test
-    public void caching() {
-        Validators.Validator v1 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( "m" ).get(),
+    public void caching() throws Exception {
+        Method method = Validatee.class.getMethod( "m", String.class );
+        Validators.Validator v1 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( method ).orElseThrow(),
             new Validatee(), false );
-        Validators.Validator v2 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( "m" ).get(),
+        Validators.Validator v2 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( method ).orElseThrow(),
             new Validatee(), false );
 
         assertThat( v1 ).isNotSameAs( v2 );
@@ -42,9 +45,7 @@ public class ValidatorsTest {
 
     public static class Validatee {
         @WsValidate( "validate" )
-        public void m( String a ) {
-
-        }
+        public void m( String a ) { }
 
         public ValidationErrors validate( String a ) {
             return ValidationErrors.empty();


### PR DESCRIPTION
Fix picking of the proper method by Reflection util for the case of several overloaded methods.

The main change here is moving from `Reflection#method(String methodName)` usage.