### PR TITLE
DD-130: Fix dataseat-dsp build

### DIFF
--- a/oap-application/src/main/java/oap/application/Kernel.java
+++ b/oap-application/src/main/java/oap/application/Kernel.java
@@ -131,7 +131,9 @@ public class Kernel implements Closeable {
             Object linked = services.get( Module.Reference.of( reference ).name );
             if( linked == null )
                 throw new ApplicationException( "for " + service.name + " listening object " + reference + " is not found" );
-            var m = Reflect.reflect( linked.getClass() ).method( methodName ).orElse( null );
+            var m = Reflect.reflect( linked.getClass() )
+                .method( methodName )
+                .orElse( null );
             if( m != null ) m.invoke( linked, instance );
             else
                 throw new ReflectException( "listener " + listener + " should have method " + methodName + " in " + reference );
@@ -208,7 +210,7 @@ public class Kernel implements Closeable {
 
         fixServiceName();
         fixDeps();
-        var map = instantiateServices( config );
+        var map = instantiateServices();
         registerServices( map );
         linkServices( map );
         startServices( map );
@@ -225,7 +227,7 @@ public class Kernel implements Closeable {
                 service.name = service.name != null ? service.name : implName );
     }
 
-    private Map<String, ServiceInitialization> instantiateServices( ApplicationConfiguration config ) {
+    private Map<String, ServiceInitialization> instantiateServices() {
         var ret = new LinkedHashMap<String, ServiceInitialization>();
 
         var initializedServices = new LinkedHashSet<String>();
@@ -277,10 +279,8 @@ public class Kernel implements Closeable {
             log.trace( "linking service {}...", si.implementationName );
             linkLinks( si.service, si.instance );
             linkListeners( si.service, si.instance );
-            si.service.parameters.forEach( ( parameter, value ) -> {
-                linkService( new FieldLinkReflection( si.reflection, si.instance, parameter ), value, si,
-                    true );
-            } );
+            si.service.parameters.forEach( ( parameter, value ) -> linkService( new FieldLinkReflection( si.reflection,
+                    si.instance, parameter ), value, si, true ) );
 
         }
     }

--- a/oap-stdlib/src/main/java/oap/reflect/Annotated.java
+++ b/oap-stdlib/src/main/java/oap/reflect/Annotated.java
@@ -27,6 +27,7 @@ import oap.util.Lists;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 abstract class Annotated<T extends java.lang.reflect.AnnotatedElement> {
@@ -59,4 +60,19 @@ abstract class Annotated<T extends java.lang.reflect.AnnotatedElement> {
     }
 
 
+    @Override
+    public boolean equals( Object o ) {
+        if( this == o ) return true;
+        if( o == null || getClass() != o.getClass() ) return false;
+        Annotated<?> annotated = ( Annotated<?> ) o;
+        System.out.println(underlying + " and " + annotated.underlying + " are: ");
+        System.out.println(Objects.equals( underlying, annotated.underlying ));
+        // TODO: make equals similar to java.lang.reflect equals methods
+        return Objects.equals( underlying.toString(), annotated.underlying.toString() );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash( underlying );
+    }
 }

--- a/oap-stdlib/src/main/java/oap/reflect/Reflection.java
+++ b/oap-stdlib/src/main/java/oap/reflect/Reflection.java
@@ -174,13 +174,36 @@ public class Reflection extends Annotated<Class<?>> {
     }
 
     public Optional<Method> method( Predicate<Method> matcher ) {
-        return this.methods.stream().filter( matcher ).findFirst();
+        return this.methods.stream()
+            .filter( matcher )
+            .findFirst();
     }
 
     public Optional<Method> method( Predicate<Method> matcher, Comparator<Method> comparator ) {
-        return this.methods.stream().sorted( comparator ).filter( matcher ).findFirst();
+        return this.methods.stream()
+            .sorted( comparator )
+            .filter( matcher )
+            .findFirst();
     }
 
+
+    /**
+     * @param name Method name
+     * @param parameters list
+     * @return {@link Method} - method wrapper of {@link java.lang.reflect.Method}
+     */
+    public Optional<Method> method( String name, List<Parameter> parameters ) {
+        return method( m -> Objects.equals( m.name(), name ) && m.parameters.equals( parameters ) );
+    }
+
+    /**
+     * @param name Method name
+     * @return {@link Method} - method wrapper of {@link java.lang.reflect.Method}
+     *
+     * @deprecated JVM is responsible to pick random method if there are several overloaded methods.
+     * Use {@link #method(String, List)} or {@link #method(java.lang.reflect.Method)} instead
+     */
+    @Deprecated
     public Optional<Method> method( String name ) {
         return method( m -> Objects.equals( m.name(), name ) );
     }
@@ -459,7 +482,6 @@ public class Reflection extends Annotated<Class<?>> {
 
         Parameter( java.lang.reflect.Parameter parameter ) {
             super( parameter );
-
         }
 
         public Reflection type() {

--- a/oap-ws/src/main/java/oap/ws/validate/JsonPartialValidatorPeer.java
+++ b/oap-ws/src/main/java/oap/ws/validate/JsonPartialValidatorPeer.java
@@ -52,7 +52,8 @@ public class JsonPartialValidatorPeer implements ValidatorPeer {
         this.validate = validate;
         this.instance = instance;
         this.method = Reflect.reflect( instance.getClass() )
-            .method( validate.methodName() )
+            .method( validate.methodName() ) // TODO: replace it with method( method, targetMethod.parameters ),
+                                             //  once the issue with @WsValidate is fixed
             .orElseThrow( () -> new WsException( "No such method " + validate.methodName() ) );
     }
 

--- a/oap-ws/src/main/java/oap/ws/validate/MethodValidatorPeer.java
+++ b/oap-ws/src/main/java/oap/ws/validate/MethodValidatorPeer.java
@@ -43,7 +43,7 @@ public class MethodValidatorPeer implements ValidatorPeer {
     public MethodValidatorPeer( WsValidate validate, Reflection.Method targetMethod, Object instance, Type type ) {
         if( type == Type.PARAMETER )
             this.validators = Stream.of( validate.value() )
-                .<Validator>map( m -> new ParameterValidator( m, instance ) )
+                .<Validator>map( m -> new ParameterValidator( m, targetMethod, instance ) )
                 .toList();
         else
             this.validators = Stream.of( validate.value() )
@@ -62,10 +62,12 @@ public class MethodValidatorPeer implements ValidatorPeer {
         protected final Reflection.Method method;
         protected final Object instance;
 
-        protected Validator( String method, Object instance ) {
+        protected Validator( String method, Reflection.Method targetMethod, Object instance ) {
             this.method = Reflect.reflect( instance.getClass() )
-                .method( method )
-                .orElseThrow( () -> new WsException( "no such method " + method ) );
+                .method( method ) // TODO: replace it with method( method, targetMethod.parameters ),
+                                  //  once the issue with @WsValidate is fixed
+                .orElseThrow( () -> new WsException( String.format( "No such method %s with the following parameters: %s",
+                    method, targetMethod.parameters ) ) );
             this.instance = instance;
         }
 
@@ -73,8 +75,8 @@ public class MethodValidatorPeer implements ValidatorPeer {
     }
 
     private static class ParameterValidator extends Validator {
-        public ParameterValidator( String method, Object instatnce ) {
-            super( method, instatnce );
+        public ParameterValidator( String method, Reflection.Method targetMethod, Object instatnce ) {
+            super( method, targetMethod, instatnce );
         }
 
         @Override
@@ -87,7 +89,7 @@ public class MethodValidatorPeer implements ValidatorPeer {
         private final Map<String, Integer> validatorMethodParamIndices;
 
         protected MethodValidator( String method, Reflection.Method targetMethod, Object instance ) {
-            super( method, instance );
+            super( method, targetMethod, instance );
             validatorMethodParamIndices = Stream.of( targetMethod.parameters )
                 .map( Reflection.Parameter::name )
                 .zipWithIndex()
@@ -103,7 +105,7 @@ public class MethodValidatorPeer implements ValidatorPeer {
                 Integer argumentIndex = validatorMethodParamIndices.get( argumentName );
                 if( argumentIndex == null ) {
                     throw new IllegalArgumentException( argumentName + " required by validator " + this.method.name()
-                        + "is not supplied by web method" );
+                        + " is not supplied by web method" );
                 }
                 params[i] = ( ( Object[] ) value )[argumentIndex];
             }
@@ -112,7 +114,9 @@ public class MethodValidatorPeer implements ValidatorPeer {
             } catch( ReflectException e ) {
                 log.error( e.getMessage() );
                 log.info( "method = " + method.name() );
-                log.info( "method parameters = " + method.parameters.stream().map( p -> p.type().underlying ).collect( toList() ) );
+                log.info( "method parameters = " + method.parameters.stream()
+                    .map( p -> p.type().underlying )
+                    .collect( toList() ) );
                 log.info( "method parameters = " + Arrays.stream( params ).map( p -> p == null ? "<NULL>"
                     : p.getClass() ).collect( toList() ) );
                 throw e;

--- a/oap-ws/src/test/java/oap/ws/ValidationTest.java
+++ b/oap-ws/src/test/java/oap/ws/ValidationTest.java
@@ -60,17 +60,16 @@ public class ValidationTest extends AbstractWebServicesTest {
 
     @Test
     public void testWrongValidatorName() {
+        String errorMessage = "No such method wrongValidatorName with the following parameters: [int requiredParameter]";
         assertGet( httpUrl( "/vaildation/service/methodWithWrongValidatorName?requiredParameter=10" ) )
-            .responded( 500, "no such method wrongValidatorName", TEXT_PLAIN.withCharset( StandardCharsets.UTF_8 ),
-                "no such method wrongValidatorName" );
+            .responded( 500, errorMessage, TEXT_PLAIN.withCharset( StandardCharsets.UTF_8 ), errorMessage );
     }
 
     @Test
     public void testValidatorWithWrongParameters() {
+        String errorMessage = "missedParam required by validator wrongArgsValidator is not supplied by web method";
         assertGet( httpUrl( "/vaildation/service/methodWithWrongValidatorArgs?requiredParameter=10" ) )
-            .responded( 500, "missedParam required by validator wrongArgsValidatoris not supplied by web method",
-                TEXT_PLAIN.withCharset( StandardCharsets.UTF_8 ),
-                "missedParam required by validator wrongArgsValidatoris not supplied by web method" );
+            .responded( 500, errorMessage, TEXT_PLAIN.withCharset( StandardCharsets.UTF_8 ), errorMessage );
     }
 
     @Test

--- a/oap-ws/src/test/java/oap/ws/validate/ValidatorsTest.java
+++ b/oap-ws/src/test/java/oap/ws/validate/ValidatorsTest.java
@@ -27,14 +27,17 @@ package oap.ws.validate;
 import oap.reflect.Reflect;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Method;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ValidatorsTest {
     @Test
-    public void caching() {
-        Validators.Validator v1 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( "m" ).get(),
+    public void caching() throws Exception {
+        Method method = Validatee.class.getMethod( "m", String.class );
+        Validators.Validator v1 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( method ).orElseThrow(),
             new Validatee(), false );
-        Validators.Validator v2 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( "m" ).get(),
+        Validators.Validator v2 = Validators.forMethod( Reflect.reflect( Validatee.class ).method( method ).orElseThrow(),
             new Validatee(), false );
 
         assertThat( v1 ).isNotSameAs( v2 );
@@ -42,9 +45,7 @@ public class ValidatorsTest {
 
     public static class Validatee {
         @WsValidate( "validate" )
-        public void m( String a ) {
-
-        }
+        public void m( String a ) { }
 
         public ValidationErrors validate( String a ) {
             return ValidationErrors.empty();

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     </distributionManagement>
 
     <properties>
-        <revision>4.8.5</revision>
+        <revision>4.8.6</revision>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 


### PR DESCRIPTION
- Added method for pick proper method in case of several overloaded methods.
  Note: the old one (deprecated) is used, until issue with @WsValidate annotation will be resolved
  (All parameters of method are validated instead of one, for which the annotation is applied)
- Fix Parameters equals method
- Bump up project version
- Fix wrong test messages in ValidationTest