### PR TITLE
OAP-98 Update Parent POM and migrate to JDK18 for OAP projects

### DIFF
--- a/.idea/jpa-buddy.xml
+++ b/.idea/jpa-buddy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JpaBuddyIdeaProjectConfig">
+    <option name="renamerInitialized" value="true" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>oap</groupId>
         <artifactId>oap.maven</artifactId>
-        <version>17.3.4.0</version>
+        <version>18.3.7.5</version>
     </parent>
 
     <packaging>pom</packaging>
@@ -36,7 +36,7 @@
     </repositories>
 
     <properties>
-        <oap.project.version>17.11.2.0</oap.project.version>
+        <oap.project.version>17.11.3.0</oap.project.version>
 
         <oap.deps.testng.version>7.7.1</oap.deps.testng.version>
         <oap.deps.assertj.version>3.23.1</oap.deps.assertj.version>


### PR DESCRIPTION
Update to the latest https://github.com/oaplatform/oap-maven