### PR TITLE
OAP 105 Profile  and module disabling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ kotlinc.xml
 /.idea/runConfigurations.xml
 /.idea/sonarlint/*
 /codemr/*
+.DS_Store

--- a/oap-stdlib/src/main/java/oap/application/ApplicationConfiguration.java
+++ b/oap-stdlib/src/main/java/oap/application/ApplicationConfiguration.java
@@ -154,7 +154,6 @@ public final class ApplicationConfiguration {
         }
     }
 
-    @SuppressWarnings( "unchecked" )
     public synchronized Set<String> getProfiles() {
         if( profilesCache != null ) return profilesCache;
         var p = new ArrayList<String>();
@@ -163,8 +162,7 @@ public final class ApplicationConfiguration {
             else if( profile instanceof Map<?, ?> ) {
                 String profileJson = Binder.json.marshal( profile );
                 var conf = Binder.json.unmarshal( ProfileMap.class, profileJson );
-                if( conf.enabled )
-                    p.add( conf.name );
+                p.add( conf.name );
             }
         }
         addProfiles( p, System.getenv() );
@@ -237,7 +235,6 @@ public final class ApplicationConfiguration {
 
     public static class ProfileMap {
         public final String name;
-        public boolean enabled = true;
 
         @JsonCreator
         public ProfileMap( String name ) {

--- a/oap-stdlib/src/main/java/oap/application/ApplicationConfiguration.java
+++ b/oap-stdlib/src/main/java/oap/application/ApplicationConfiguration.java
@@ -148,7 +148,6 @@ public final class ApplicationConfiguration {
         while( it.hasPrevious() ) {
             var profile = it.previous();
 
-            if( profile.startsWith( "-" ) ) profile = profile.substring( 1 );
             if( cache.contains( profile ) ) it.remove();
             else cache.add( profile );
         }
@@ -177,7 +176,7 @@ public final class ApplicationConfiguration {
         profilesCache = null;
     }
 
-    private void addProfiles( List<String> ret, Map<? extends Object, ? extends Object> env ) {
+    private void addProfiles( List<String> ret, Map<?, ?> env ) {
         env.forEach( ( nameObj, valueObj ) -> {
             var name = ( String ) nameObj;
             var value = ( String ) valueObj;
@@ -187,8 +186,8 @@ public final class ApplicationConfiguration {
                 profileName = profileEscape( profileName );
                 var enabled = "1".equals( profileValue ) || "ON".equals( profileValue ) || "TRUE".equals( profileValue );
 
-                ret.remove( ( enabled ? "-" : "" ) + profileName );
-                ret.add( ( enabled ? "" : "-" ) + profileName );
+//                ret.remove( ( enabled ? "-" : "" ) + profileName );
+//                ret.add( ( enabled ? "" : "-" ) + profileName );
             }
         } );
     }

--- a/oap-stdlib/src/main/java/oap/application/ApplicationConfiguration.java
+++ b/oap-stdlib/src/main/java/oap/application/ApplicationConfiguration.java
@@ -146,10 +146,7 @@ public final class ApplicationConfiguration {
 
         var it = profiles.listIterator( profiles.size() );
         while( it.hasPrevious() ) {
-            var profile = it.previous();
-
-            if( cache.contains( profile ) ) it.remove();
-            else cache.add( profile );
+            cache.add( it.previous() );
         }
     }
 
@@ -179,15 +176,10 @@ public final class ApplicationConfiguration {
     private void addProfiles( List<String> ret, Map<?, ?> env ) {
         env.forEach( ( nameObj, valueObj ) -> {
             var name = ( String ) nameObj;
-            var value = ( String ) valueObj;
             if( name.startsWith( OAP_PROFILE_PREFIX ) ) {
                 var profileName = name.substring( OAP_PROFILE_PREFIX.length() );
-                var profileValue = value.trim().toUpperCase();
                 profileName = profileEscape( profileName );
-                var enabled = "1".equals( profileValue ) || "ON".equals( profileValue ) || "TRUE".equals( profileValue );
-
-//                ret.remove( ( enabled ? "-" : "" ) + profileName );
-//                ret.add( ( enabled ? "" : "-" ) + profileName );
+                ret.add( profileName );
             }
         } );
     }

--- a/oap-stdlib/src/main/java/oap/application/Kernel.java
+++ b/oap-stdlib/src/main/java/oap/application/Kernel.java
@@ -191,7 +191,7 @@ public class Kernel implements Closeable, AutoCloseable {
 
     private void checkForUnknownServices( Map<String, ApplicationConfigurationModule> services ) throws ApplicationException {
         services.forEach( ( moduleName, conf ) -> {
-            if( !Lists.contains( this.modules, m -> m.module.name.equals( moduleName ) ) && conf.isEnabled() )
+            if( !Lists.contains( this.modules, m -> m.module.name.equals( moduleName ) ) )
                 throw new ApplicationException( "unknown application configuration module: " + moduleName );
         } );
 

--- a/oap-stdlib/src/main/java/oap/application/KernelHelper.java
+++ b/oap-stdlib/src/main/java/oap/application/KernelHelper.java
@@ -133,9 +133,9 @@ public class KernelHelper {
         return new ServiceConfigurationParameter( value, false );
     }
 
-    public static boolean profileEnabled(LinkedHashSet<String> moduleProfiles, LinkedHashSet<String> systemProfiles) {
-        for (var profile : moduleProfiles) {
-            if (!systemProfiles.contains(profile)) return false;
+    public static boolean profileEnabled( LinkedHashSet<String> moduleProfiles, LinkedHashSet<String> systemProfiles ) {
+        for ( var profile : moduleProfiles ) {
+            if ( !systemProfiles.contains( profile ) ) return false;
         }
         return true;
     }
@@ -148,8 +148,8 @@ public class KernelHelper {
         return profileEnabled( service.profiles, systemProfiles ) && !hasDisabledProfile( service.profiles );
     }
 
-    public static boolean hasDisabledProfile(LinkedHashSet<String> profiles) {
-        return profiles.contains("disabled");
+    public static boolean hasDisabledProfile( LinkedHashSet<String> profiles ) {
+        return profiles.contains( "disabled" );
     }
 
     public static void setThreadNameSuffix( String suffix ) {

--- a/oap-stdlib/src/main/java/oap/application/KernelHelper.java
+++ b/oap-stdlib/src/main/java/oap/application/KernelHelper.java
@@ -133,23 +133,23 @@ public class KernelHelper {
         return new ServiceConfigurationParameter( value, false );
     }
 
-    public static boolean profileEnabled( LinkedHashSet<String> moduleProfiles, LinkedHashSet<String> systemProfiles ) {
-        for( var profile : moduleProfiles ) {
-            if( profile.startsWith( "-" ) ) {
-                if( systemProfiles.contains( profile.substring( 1 ) ) ) return false;
-            } else {
-                if( !systemProfiles.contains( profile ) ) return false;
-            }
+    public static boolean profileEnabled(LinkedHashSet<String> moduleProfiles, LinkedHashSet<String> systemProfiles) {
+        for (var profile : moduleProfiles) {
+            if (!systemProfiles.contains(profile)) return false;
         }
         return true;
     }
 
     public static boolean isModuleEnabled( Module module, LinkedHashSet<String> systemProfiles ) {
-        return profileEnabled( module.profiles, systemProfiles );
+        return profileEnabled( module.profiles, systemProfiles ) && !hasDisabledProfile( module.profiles );
     }
 
     public static boolean isServiceEnabled( Service service, LinkedHashSet<String> systemProfiles ) {
-        return profileEnabled( service.profiles, systemProfiles );
+        return profileEnabled( service.profiles, systemProfiles ) && !hasDisabledProfile( service.profiles );
+    }
+
+    public static boolean hasDisabledProfile(LinkedHashSet<String> profiles) {
+        return profiles.contains("disabled");
     }
 
     public static void setThreadNameSuffix( String suffix ) {

--- a/oap-stdlib/src/main/resources/META-INF/oap-module.conf
+++ b/oap-stdlib/src/main/resources/META-INF/oap-module.conf
@@ -8,7 +8,7 @@ services {
 
   oap-time-joda {
     name = oap-time
-    profile = -java-time
+    profile = disabled
     implementation = oap.time.JodaTimeService
   }
 

--- a/oap-stdlib/src/test/java/oap/application/ApplicationConfigurationTest.java
+++ b/oap-stdlib/src/test/java/oap/application/ApplicationConfigurationTest.java
@@ -70,14 +70,13 @@ public class ApplicationConfigurationTest {
         assertThat( ac.getProfiles() ).isEmpty();
         ac.reset();
 
-        ac.profiles.add( "-with-file" );
         ac.profiles.add( "test" );
 
         System.setProperty( "OAP_PROFILE_with__file", "1" );
         Env.set( "OAP_PROFILE_with_2Dfile", "on" );
         Env.set( "OAP_PROFILE_test", "false" );
 
-        assertThat( ac.getProfiles() ).containsOnly( "with_file", "with-file", "-test" );
+        assertThat( ac.getProfiles() ).containsOnly( "test", "with_file", "with-file" );
     }
 
     @Test
@@ -90,12 +89,11 @@ public class ApplicationConfigurationTest {
         assertThat( ac.getProfiles() ).containsExactly( "test" );
         ac.reset();
 
-        ac.profiles.add( "-test" );
         ac.profiles.add( "b" );
-        assertThat( ac.getProfiles() ).containsExactly( "-test", "b" );
+        assertThat( ac.getProfiles() ).containsExactly( "test", "b" );
         ac.reset();
 
         ac.profiles.add( "test" );
-        assertThat( ac.getProfiles() ).containsExactly( "b", "test" );
+        assertThat( ac.getProfiles() ).containsExactly( "test", "b" );
     }
 }

--- a/oap-stdlib/src/test/java/oap/application/KernelProfileTest.java
+++ b/oap-stdlib/src/test/java/oap/application/KernelProfileTest.java
@@ -24,14 +24,12 @@
 
 package oap.application;
 
-import com.typesafe.config.impl.ConfigImpl;
 import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static oap.testng.Asserts.pathOfTestResource;
 import static oap.testng.Asserts.urlOfTestResource;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,11 +51,15 @@ public class KernelProfileTest {
 
         try( var kernel = new Kernel( modules ) ) {
             startWithProfile( kernel, "test-profile", "profile-name1" );
+            assertThat( kernel.<TestProfile1>service( "*.profile" ) ).isNotPresent();
+        }
+        try( var kernel = new Kernel( modules ) ) {
+            startWithProfile( kernel, "test-profile", "profile-name1", "profile-name2" );
             assertThat( kernel.<TestProfile1>service( "*.profile" ) ).isPresent();
         }
         try( var kernel = new Kernel( modules ) ) {
             startWithProfile( kernel, "test-profile", "profile-name1", "profile-name2" );
-            assertThat( kernel.<TestProfile1>service( "*.profile" ) ).isNotPresent();
+            assertThat( kernel.<TestProfile1>service( "*.disabledProfile" ) ).isNotPresent();
         }
         try( var kernel = new Kernel( modules ) ) {
             startWithProfile( kernel, "test-profile", "profile-name2" );
@@ -81,7 +83,7 @@ public class KernelProfileTest {
             startWithProfile( kernel, "test-profile", "profile-name-2" );
 
             assertThat( kernel.<TestProfile1>service( "*.profile1" ) ).isNotPresent();
-            assertThat( kernel.<TestProfile2>service( "*.profile2" ) ).isPresent();
+            assertThat( kernel.<TestProfile2>service( "*.profile2" ) ).isNotPresent();
             assertThat( kernel.<TestProfile3>service( "*.profile3" ) ).isPresent();
         }
     }
@@ -130,35 +132,6 @@ public class KernelProfileTest {
         try( var kernel = new Kernel( List.of( urlOfTestResource( getClass(), "module-profile.yaml" ) ) ) ) {
             startWithProfile( kernel, "test-module-profile" );
             assertThat( kernel.service( "*.module-profile" ) ).isNotPresent();
-        }
-    }
-
-    @Test
-    public void testDynamicProfile() {
-        ConfigImpl.reloadSystemPropertiesConfig();
-        try( var kernel = new Kernel( List.of( urlOfTestResource( getClass(), "module-profile.conf" ) ) ) ) {
-            kernel.start( pathOfTestResource( getClass(), "application-profile.conf" ) );
-
-            assertThat( kernel.<TestProfile1>service( "*.profile1" ) ).isPresent();
-            assertThat( kernel.<TestProfile2>service( "*.profile2" ) ).isPresent();
-        }
-
-        System.setProperty( "ENABLE_TEST_PROFILE", "true" );
-        ConfigImpl.reloadSystemPropertiesConfig();
-        try( var kernel = new Kernel( List.of( urlOfTestResource( getClass(), "module-profile.conf" ) ) ) ) {
-            kernel.start( pathOfTestResource( getClass(), "application-profile.conf" ) );
-
-            assertThat( kernel.<TestProfile1>service( "*.profile1" ) ).isPresent();
-            assertThat( kernel.<TestProfile2>service( "*.profile2" ) ).isPresent();
-        }
-
-        System.setProperty( "ENABLE_TEST_PROFILE", "false" );
-        ConfigImpl.reloadSystemPropertiesConfig();
-        try( var kernel = new Kernel( List.of( urlOfTestResource( getClass(), "module-profile.conf" ) ) ) ) {
-            kernel.start( pathOfTestResource( getClass(), "application-profile.conf" ) );
-
-            assertThat( kernel.<TestProfile1>service( "*.profile1" ) ).isNotPresent();
-            assertThat( kernel.<TestProfile2>service( "*.profile2" ) ).isPresent();
         }
     }
 

--- a/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/application-profile.conf
+++ b/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/application-profile.conf
@@ -3,7 +3,6 @@ boot.main = module-profile
 profiles = [
   {
     name = test-profile
-    enabled = ${?ENABLE_TEST_PROFILE}
   }
   test-profile2
 ]

--- a/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module-profiles.yaml
+++ b/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module-profiles.yaml
@@ -3,5 +3,10 @@ services:
   profile:
     profiles:
       - profile-name1
-      - -profile-name2
+      - profile-name2
+    implementation: "oap.application.KernelProfileTest$TestProfile1"
+  disabledProfile:
+    profiles:
+      - profile-name1
+      - disabled
     implementation: "oap.application.KernelProfileTest$TestProfile1"

--- a/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module.yaml
+++ b/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module.yaml
@@ -5,7 +5,7 @@ services:
     implementation: "oap.application.KernelProfileTest$TestProfile1"
 
   profile2:
-    profile: -profile-name
+    profile: disabled
     implementation: "oap.application.KernelProfileTest$TestProfile2"
 
   profile3:

--- a/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module4.yaml
+++ b/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module4.yaml
@@ -11,7 +11,6 @@ services:
 
   container2:
     profiles:
-      - -profile-name
       - run
     name: container
     implementation: oap.application.KernelProfileTest$TestContainer2

--- a/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module5.yaml
+++ b/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module5.yaml
@@ -5,22 +5,17 @@ dependsOn:
 services:
   profile2:
     profiles:
-      - -profile-name
       - run
     implementation: oap.application.KernelProfileTest$TestProfile2
     name: profile
 
   profile1:
     profiles:
-      - -profile-name
-      - -run
+      - disabled
     implementation: oap.application.KernelProfileTest$TestProfile1
     name: profile
 
   container2:
-    profiles:
-      - -profile-name
-      - run
     name: container
     implementation: oap.application.KernelProfileTest$TestContainer3
     parameters:

--- a/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module6.conf
+++ b/oap-stdlib/src/test/resources/oap/application/KernelProfileTest/module6.conf
@@ -24,7 +24,7 @@ services {
   }
   profile2 {
     name = profile
-    profile = -run
+    profile = disable
     implementation = "oap.application.KernelProfileTest$TestProfile2"
   }
   profile-11 {

--- a/oap-stdlib/src/test/resources/oap/application/KernelTest/disabled/disabled.conf
+++ b/oap-stdlib/src/test/resources/oap/application/KernelTest/disabled/disabled.conf
@@ -12,8 +12,8 @@
       dependsOn = [s2]
     }
     s2 {
+      profiles = [disabled]
       implementation = oap.application.ServiceOne
-      enabled = false
       parameters {
         i = 2
       }


### PR DESCRIPTION
Removed disabling with minus Profiles functionality
Remove direct disabling OAP dependecies ( [dependency-name].[profile-name].enable = false )
To disable module use "profile - disabled" approach

